### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ansible
+behave
+markupsafe
+six>=1.9.0


### PR DESCRIPTION
I've tried to run ctf-cli on rhel7 and figured out at least these dependencies:

ansible
behave
markupsafe
six>=1.9.0
