### PR TITLE
Add 'init', 'run' and 'update' subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The `tests.conf` file contains configuration telling the CTF what extra remote t
     Steps=https://github.com/Containers-Testing-Framework/common-steps.git
     Features=https://github.com/Containers-Testing-Framework/common-features.git
 
+#### This method is not recommended and will soon be deprecated - git submodules way would be preferred
+
+
 ### environment.py
 You can implement some of the methods that are typically used with Behave inside this file. It will be combined with the CTF common `environment.py` file. This integration may not be perfect yet, feel free to test and provide feedback.
 

--- a/ctf_cli/application.py
+++ b/ctf_cli/application.py
@@ -23,7 +23,7 @@ from ctf_cli.exceptions import CTFCliError
 from ctf_cli.common_environment import common_environment_py_content, sample_ctl_ctf_config
 
 import os
-import shutil
+from subprocess import call
 
 
 class Application(object):
@@ -101,11 +101,11 @@ class Application(object):
         # Add common-features and common-steps as submodules
 
         # TODO:  make this generic when a different type of container is specified
-        common_features_dir = os.path.join(features_dir, "common-docker")
+        common_features_dir = os.path.join(features_dir, "common-features")
         if os.path.exists(common_features_dir):
-            logger.info("Directory tests/features/common-docker already exists")
+            logger.info("Directory tests/features/common-features already exists")
         else:
-            logger.info("Adding tests/features/common-docker as a submodule")
+            logger.info("Adding tests/features/common-features as a submodule")
             os.system('git submodule add https://github.com/Containers-Testing-Framework/common-features.git tests/features/common-features')
 
         common_steps_dir = os.path.join(steps_dir, "common_steps")
@@ -161,4 +161,15 @@ class Application(object):
         """
         Update app submodules
         """
-        pass
+        logger.info("Updating Containers Testing Framework common steps and features")
+
+        common_steps_dir = os.path.join(self._execution_dir_path, "tests", "steps", "common_steps")
+        common_features_dir = os.path.join(self._execution_dir_path, "tests", "features", "common-features")
+        for directory in [common_steps_dir, common_features_dir]:
+            logger.info("Updating %s" % directory)
+            call("git fetch origin", shell=True, cwd=directory)
+            call("git checkout origin/master", shell=True, cwd=directory)
+
+        # Check that steps are not contradicting with each other
+        logger.info("Checking project steps sanity")
+        call("behave tests -d", shell=True)

--- a/ctf_cli/application.py
+++ b/ctf_cli/application.py
@@ -40,6 +40,19 @@ class Application(object):
             cli_args.cli_config_path = CTFCliConfig.find_cli_config(self._execution_dir_path)
         self._cli_conf = CTFCliConfig(cli_args)
 
+    def init(self):
+        """
+        Initialize default app test structure
+        """
+        logger.info("Initialize default directory structure")
+        pass
+
+    def run(self):
+        """
+        The main application execution method
+        """
+        logger.info("Running Containers Testing Framework cli")
+
         # If no Dockerfile passed on the cli, try to use one from the execution directory
         if not self._cli_conf.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE):
             local_file = os.path.join(self._execution_dir_path, 'Dockerfile')
@@ -53,12 +66,6 @@ class Application(object):
         if self._cli_conf.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_EXEC_TYPE) != 'ansible':
             raise CTFCliError("Wrong ExecType configured. Currently only 'ansible' is supported!")
 
-    def run(self):
-        """
-        The main application execution method
-        """
-        logger.info("Running Containers Testing Framework cli")
-
         self._working_dir = BehaveWorkingDirectory(self._working_dir_path, self._cli_conf)
 
         # Setup Behave structure inside working directory
@@ -70,3 +77,9 @@ class Application(object):
         # Execute Behave
         self._behave_runner = BehaveRunner(self._working_dir, self._cli_conf)
         return self._behave_runner.run()
+
+    def update(self):
+        """
+        Update app submodules
+        """
+        pass

--- a/ctf_cli/application.py
+++ b/ctf_cli/application.py
@@ -20,7 +20,7 @@ from ctf_cli.logger import logger
 from ctf_cli.config import CTFCliConfig
 from ctf_cli.behave import BehaveWorkingDirectory, BehaveRunner
 from ctf_cli.exceptions import CTFCliError
-from ctf_cli.common_environment import common_environment_py_content, sample_ctl_ctf_config
+from ctf_cli.common_environment import common_environment_py_content, sample_ctl_ctf_config, common_steps_py_content
 
 import os
 from subprocess import check_call
@@ -99,8 +99,16 @@ class Application(object):
             open(steps_init_file, "a").close()
             check_call("git add %s" % steps_init_file, shell=True)
 
-        # Add common-features and common-steps as submodules
+        steps_py_file = os.path.join(steps_dir, "steps.py")
+        if os.path.exists(steps_py_file):
+            logger.info("File tests/steps/steps.py already exists")
+        else:
+            logger.info("Creating tests/steps/steps.py file")
+            with open(steps_py_file, "w") as f:
+                f.write(common_steps_py_content)
+            check_call("git add %s" % steps_py_file, shell=True)
 
+        # Add common-features and common-steps as submodules
         # TODO:  make this generic when a different type of container is specified
         common_features_dir = os.path.join(features_dir, "common-features")
         if os.path.exists(common_features_dir):

--- a/ctf_cli/application.py
+++ b/ctf_cli/application.py
@@ -23,7 +23,7 @@ from ctf_cli.exceptions import CTFCliError
 from ctf_cli.common_environment import common_environment_py_content, sample_ctl_ctf_config
 
 import os
-from subprocess import call
+from subprocess import check_call
 
 
 class Application(object):
@@ -49,10 +49,11 @@ class Application(object):
         logger.info("Initialize default directory structure")
 
         # Make sure we're in a directory under git control
-        if not os.path.isdir(".git") or \
-           os.system('git rev-parse 2> /dev/null > /dev/null') != 0:
+        try:
+            check_call('git rev-parse', shell=True)
+        except:
             logger.info("Directory is not under git control, running git init")
-            os.system("git init")
+            check_call("git init", shell=True)
 
         # Create test dir if it is missing
         tests_dir = os.path.join(self._execution_dir_path, "tests")
@@ -61,7 +62,7 @@ class Application(object):
         else:
             logger.info("Creating tests directory")
             os.mkdir(tests_dir)
-            os.system("git add %s" % tests_dir)
+            check_call("git add %s" % tests_dir, shell=True)
 
         env_py_path = os.path.join(tests_dir, "environment.py")
         if os.path.exists(env_py_path):
@@ -71,7 +72,7 @@ class Application(object):
             # Create environment.py
             with open(env_py_path, "w") as f:
                 f.write(common_environment_py_content)
-            os.system("git add %s" % env_py_path)
+            check_call("git add %s" % env_py_path, shell=True)
 
         features_dir = os.path.join(tests_dir, "features")
         if os.path.exists(features_dir):
@@ -79,7 +80,7 @@ class Application(object):
         else:
             logger.info("Creating tests/features directory")
             os.mkdir(features_dir)
-            os.system("git add %s" % features_dir)
+            check_call("git add %s" % features_dir, shell=True)
 
         steps_dir = os.path.join(tests_dir, "steps")
         if os.path.exists(steps_dir):
@@ -87,7 +88,7 @@ class Application(object):
         else:
             logger.info("Creating tests/steps directory")
             os.mkdir(steps_dir)
-            os.system("git add %s" % steps_dir)
+            check_call("git add %s" % steps_dir, shell=True)
 
         # TODO: check that this file is actually necessary
         steps_init_file = os.path.join(steps_dir, "__init__.py")
@@ -96,7 +97,7 @@ class Application(object):
         else:
             logger.info("Creating tests/steps/__init__.py file")
             open(steps_init_file, "a").close()
-            os.system("git add %s" % steps_init_file)
+            check_call("git add %s" % steps_init_file, shell=True)
 
         # Add common-features and common-steps as submodules
 
@@ -106,14 +107,14 @@ class Application(object):
             logger.info("Directory tests/features/common-features already exists")
         else:
             logger.info("Adding tests/features/common-features as a submodule")
-            os.system('git submodule add https://github.com/Containers-Testing-Framework/common-features.git tests/features/common-features')
+            check_call('git submodule add https://github.com/Containers-Testing-Framework/common-features.git tests/features/common-features', shell=True)
 
         common_steps_dir = os.path.join(steps_dir, "common_steps")
         if os.path.exists(common_steps_dir):
             logger.info("Directory tests/steps/common_steps already exists")
         else:
             logger.info("Adding tests/steps/common_steps as a submodule")
-            os.system('git submodule add https://github.com/Containers-Testing-Framework/common-steps.git tests/steps/common_steps')
+            check_call('git submodule add https://github.com/Containers-Testing-Framework/common-steps.git tests/steps/common_steps', shell=True)
 
         # Copy sample configuration
         ctf_conf_file = os.path.join(self._execution_dir_path, "ctf.conf")
@@ -124,7 +125,7 @@ class Application(object):
             # Create environment.py
             with open(ctf_conf_file, "w") as f:
                 f.write(sample_ctl_ctf_config)
-            os.system("git add %s" % ctf_conf_file)
+            check_call("git add %s" % ctf_conf_file, shell=True)
 
     def run(self):
         """
@@ -167,9 +168,9 @@ class Application(object):
         common_features_dir = os.path.join(self._execution_dir_path, "tests", "features", "common-features")
         for directory in [common_steps_dir, common_features_dir]:
             logger.info("Updating %s" % directory)
-            call("git fetch origin", shell=True, cwd=directory)
-            call("git checkout origin/master", shell=True, cwd=directory)
+            check_call("git fetch origin", shell=True, cwd=directory)
+            check_call("git checkout origin/master", shell=True, cwd=directory)
 
         # Check that steps are not contradicting with each other
         logger.info("Checking project steps sanity")
-        call("behave tests -d", shell=True)
+        check_call("behave tests -d", shell=True)

--- a/ctf_cli/arguments_parser.py
+++ b/ctf_cli/arguments_parser.py
@@ -30,6 +30,13 @@ class ArgumentsParser(object):
 
     def add_args(self):
         self.parser.add_argument(
+            dest='cli_action',
+            choices=['init', 'run', 'update'],
+            default=['init', 'run'],
+            nargs='?',
+            help="Action to perform (default - init and run)"
+        )
+        self.parser.add_argument(
             "-v",
             "--verbose",
             default=False,

--- a/ctf_cli/cli_runner.py
+++ b/ctf_cli/cli_runner.py
@@ -48,7 +48,12 @@ class CliRunner(object):
                                                 logging.INFO)
 
             app = Application(args)
-            app.run()
+            if 'init' in args.cli_action:
+                app.init()
+            if 'run' in args.cli_action:
+                app.run()
+            if 'update' in args.cli_action:
+                app.update()
         except KeyboardInterrupt:
             logger.info('Interrupted by user')
         except CTFCliError as e:

--- a/ctf_cli/common_environment.py
+++ b/ctf_cli/common_environment.py
@@ -142,3 +142,18 @@ def after_all(context):
         shutil.rmtree(context.temp_dir) #FIXME catch exception
 
 """
+
+sample_ctl_ctf_config = """
+[ctf]
+#Verbose=yes
+#CLIConfPath=/etc/ctf.conf
+#TestsConfigPath=/etc/ctf-tests.conf
+#Dockerfile=/home/user/my_cool_project/Dockerfile
+#Image=centos:centos7
+ExecType=ansible
+
+[ansible]
+Host=192.168.1.1
+Method=ssh
+User=root
+"""

--- a/ctf_cli/common_environment.py
+++ b/ctf_cli/common_environment.py
@@ -157,3 +157,8 @@ Host=192.168.1.1
 Method=ssh
 User=root
 """
+
+common_steps_py_content = """# -*- coding: utf-8 -*-
+from common_steps.common_connection_steps import *
+from common_steps.common_docker_steps import *
+"""


### PR DESCRIPTION
Adding subcommands (as discussed in #2) would simplify creating new tests, running them and updating to tests from submodules.

`init` subcommand creates a sample project with basic tests (importing `common-steps` and 
`common-features` as submodules).

`run` command is left intact.

`update` subcommand fetches new code from common-steps and common-features submodules and runs behave in dry mode to make sure step definitions are valid.
