### PR TITLE
Support exporting Junit results

### DIFF
--- a/ctf_cli/arguments_parser.py
+++ b/ctf_cli/arguments_parser.py
@@ -64,6 +64,13 @@ class ArgumentsParser(object):
             dest='image',
             help="Image to use for testing. If not passed, the image will be built from the Dockerfile."
         )
+        self.parser.add_argument(
+            "-j",
+            "--junit",
+            default=None,
+            dest='junit',
+            help="Junit folder to store results. If not passed junit reports will not be generated"
+        )
 
     def __getattr__(self, name):
         try:

--- a/ctf_cli/behave.py
+++ b/ctf_cli/behave.py
@@ -419,6 +419,7 @@ class BehaveRunner(object):
         """
         image = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_IMAGE)
         dockerfile = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE)
+        junit = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_JUNIT)
 
         # configuration file for ansible
         if self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_EXEC_TYPE) == 'ansible':
@@ -430,6 +431,10 @@ class BehaveRunner(object):
             'behave',
             '-D', 'DOCKERFILE={0}'.format(dockerfile),
         ]
+
+        if junit:
+            command.append('--junit')
+            command.append('--junit-directory={0}'.format(junit))
 
         if image:
             command.extend(['-D', 'IMAGE={0}'.format(image)])

--- a/ctf_cli/config.py
+++ b/ctf_cli/config.py
@@ -37,6 +37,7 @@ class CTFCliConfig(object):
     CONFIG_TESTS_CONFIG_PATH = 'TestsConfigPath'
     CONFIG_DOCKERFILE = 'Dockerfile'
     CONFIG_IMAGE = 'Image'
+    CONFIG_JUNIT = 'Junit'
     CONFIG_EXEC_TYPE = 'ExecType'
 
     ANSIBLE_SECTION_NAME = 'ansible'
@@ -97,6 +98,7 @@ class CTFCliConfig(object):
             self.CONFIG_DOCKERFILE: os.path.abspath(
                 cli_conf.dockerfile) if cli_conf.dockerfile else None,
             self.CONFIG_IMAGE: cli_conf.image,
+            self.CONFIG_JUNIT: cli_conf.junit,
             self.CONFIG_EXEC_TYPE: 'ansible',
         }}
 


### PR DESCRIPTION
Append -j <junit-dir-path> to ctf-cli or
set "Junit=<junit-dir-path>" in config to
export junit reports to this dir

Fixes #6
