### PR TITLE
Stop container in after_scenario

### DIFF
--- a/ctf_cli/common_environment.py
+++ b/ctf_cli/common_environment.py
@@ -24,7 +24,7 @@ common_environment_py_header = """# -*- coding: utf-8 -*-
 """
 
 common_environment_py_content = """
-# Some useful functions for your environment.py
+#Some useful functions for your environment.py
 import tempfile
 import shutil
 import ansible.runner
@@ -121,8 +121,13 @@ def before_all(context):
     cid_file_name = re.sub(r'\W+', '', context.image)
     context.cid_file = "/tmp/%s.cid" % cid_file_name
 
+def after_scenario(context, scenario):
+    try:
+        if context.config.userdata['KEEP_IMAGE_AFTER_TEST']:
+            return
+    except KeyError, e:
+        pass
 
-def before_scenario(context, scenario):
     try:
         cid = context.run('cat %s' % context.cid_file)
     except AssertionError, e:

--- a/ctf_cli/common_environment.py
+++ b/ctf_cli/common_environment.py
@@ -24,7 +24,7 @@ common_environment_py_header = """# -*- coding: utf-8 -*-
 """
 
 common_environment_py_content = """
-#Some useful functions for your environment.py
+# Some useful functions for your environment.py
 import tempfile
 import shutil
 import ansible.runner
@@ -123,7 +123,7 @@ def before_all(context):
 
 def after_scenario(context, scenario):
     try:
-        if context.config.userdata['KEEP_IMAGE_AFTER_TEST']:
+        if context.config.userdata['KEEP_CONTAINER_AFTER_TEST']:
             return
     except KeyError, e:
         pass


### PR DESCRIPTION
I think stopping container in after_scenario method is better. it cleans the stuff just when it is not required anymore - this also assures that container is stopped after last test.
Also I think there should be an option to not stop the container at all (it can be started in before_scenario and reused through all tests)
