### PR TITLE
Tags 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ test:
     - cd test_dir && COVAREGE_FILE=../.coverage.remote_steps coverage run ../ctf-cli.py remote add steps https://github.com/Containers-Testing-Framework/common-steps.git
     - cd test_dir && COVAREGE_FILE=../.coverage.remote_feature coverage run ../ctf-cli.py remote add features https://github.com/Containers-Testing-Framework/common-features.git
     - cd test_dir && COVERAGE_FILE=../.coverage.update coverage run ../ctf-cli.py update
-    - cd test_dir && COVERAGE_FILE=../.coverage.run coverage run ../ctf-cli.py run
+    - cd test_dir && COVERAGE_FILE=../.coverage.run coverage run ../ctf-cli.py run --behave-data DOCKERFILE=Dockerfile
     - COVERAGE_FILE=.coverage.tests nosetests
     - coverage combine
     - coveralls

--- a/ctf_cli/application.py
+++ b/ctf_cli/application.py
@@ -154,16 +154,6 @@ class Application(object):
         """
         logger.info("Running Containers Testing Framework cli")
 
-        # If no Dockerfile passed on the cli, try to use one from the execution directory
-        if not self._cli_conf.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE):
-            local_file = os.path.join(self._execution_dir_path, 'Dockerfile')
-            if os.path.isfile(local_file):
-                logger.debug("Using Dockerfile from the current directory.")
-                self._cli_conf.set(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE, local_file)
-            else:
-                logger.debug("No Dockerfile specified and none found in current directory.")
-                self._cli_conf.set(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE, None)
-
         # TODO: Remove this or rework, once more types are implemented
         if self._cli_conf.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_EXEC_TYPE) != 'ansible':
             raise CTFCliError("Wrong ExecType configured. Currently only 'ansible' is supported!")

--- a/ctf_cli/arguments_parser.py
+++ b/ctf_cli/arguments_parser.py
@@ -78,18 +78,20 @@ class ArgumentsParser(object):
             help="Path to tests configuration file. By default it will be searched for in test/ dir"
         )
         run_subparser.add_argument(
-            "-f",
-            "--dockerfile",
+            "-d",
+            "--behave-data",
+            action='append',
             default=None,
-            dest='dockerfile',
-            help="Path to Dockerfile to use. If not passed, will be searched for in the current directory"
+            dest='behave_data',
+            help="A way to set behave userdata"
         )
         run_subparser.add_argument(
-            "-i",
-            "--image",
+            "-b",
+            "--behave-tags",
+            action='append',
             default=None,
-            dest='image',
-            help="Image to use for testing. If not passed, the image will be built from the Dockerfile."
+            dest='behave_tags',
+            help="A way to set behave test tags"
         )
         run_subparser.add_argument(
             "-j",

--- a/ctf_cli/behave.py
+++ b/ctf_cli/behave.py
@@ -422,8 +422,9 @@ class BehaveRunner(object):
         Run Behave and pass some runtime arguments
         :return:
         """
-        image = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_IMAGE)
-        dockerfile = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_DOCKERFILE)
+
+        behave_data = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_BEHAVE_DATA)
+        behave_tags = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_BEHAVE_TAGS)
         junit = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_JUNIT)
         verbose = self._cli_conf_obj.get(CTFCliConfig.GLOBAL_SECTION_NAME, CTFCliConfig.CONFIG_VERBOSE)
 
@@ -434,8 +435,7 @@ class BehaveRunner(object):
             ansible_conf = None
 
         command = [
-            'behave',
-            '-D', 'DOCKERFILE={0}'.format(dockerfile),
+            'behave'
         ]
         if verbose == "yes":
             command.append('-v')
@@ -444,8 +444,17 @@ class BehaveRunner(object):
             command.append('--junit')
             command.append('--junit-directory={0}'.format(junit))
 
-        if image:
-            command.extend(['-D', 'IMAGE={0}'.format(image)])
+        if behave_data:
+            #FIXME hacky otherwise it return string - seems like wierd buig in config.py
+            for userdata in behave_data.split('\n'):
+                command.extend(['-D', '{0}'.format(userdata)])
+
+        if behave_tags:
+            #FIXME hacky otherwise it return string - seems like wierd buig in config.py
+            for tag in behave_tags.split('\n'):
+                command.extend(['-t', '{0}'.format(tag)])
+                if verbose != "yes":
+                    command.append('--no-skipped')
 
         if ansible_conf:
             command.extend(['-D', 'ANSIBLE={0}'.format(ansible_conf)])

--- a/ctf_cli/behave.py
+++ b/ctf_cli/behave.py
@@ -446,12 +446,16 @@ class BehaveRunner(object):
 
         if behave_data:
             #FIXME hacky otherwise it return string - seems like wierd buig in config.py
-            for userdata in behave_data.split('\n'):
+            if type(behave_data) is str:
+                behave_data = behave_data.split('\n')
+            for userdata in behave_data:
                 command.extend(['-D', '{0}'.format(userdata)])
 
         if behave_tags:
             #FIXME hacky otherwise it return string - seems like wierd buig in config.py
-            for tag in behave_tags.split('\n'):
+            if type(behave_tags) is str:
+                behave_tags = behave_tags.split('\n')
+            for tag in behave_tags:
                 command.extend(['-t', '{0}'.format(tag)])
                 if verbose != "yes":
                     command.append('--no-skipped')

--- a/ctf_cli/config.py
+++ b/ctf_cli/config.py
@@ -34,8 +34,8 @@ class CTFCliConfig(object):
     CONFIG_VERBOSE = 'Verbose'
     CONFIG_CLI_CONFIG_PATH = 'CLIConfigPath'
     CONFIG_TESTS_CONFIG_PATH = 'TestsConfigPath'
-    CONFIG_DOCKERFILE = 'Dockerfile'
-    CONFIG_IMAGE = 'Image'
+    CONFIG_BEHAVE_DATA = 'BehaveData'
+    CONFIG_BEHAVE_TAGS = 'BehaveTags'
     CONFIG_JUNIT = 'Junit'
     CONFIG_EXEC_TYPE = 'ExecType'
     CONFIG_REMOTE_TYPE = 'remote_type'
@@ -98,9 +98,8 @@ class CTFCliConfig(object):
             self.CONFIG_CLI_CONFIG_PATH: os.path.abspath(cli_conf.cli_config_path) if cli_conf.cli_config_path else '',
             self.CONFIG_TESTS_CONFIG_PATH: os.path.abspath(
                 cli_conf.tests_config_path)if cli_conf.tests_config_path else None,
-            self.CONFIG_DOCKERFILE: os.path.abspath(
-                cli_conf.dockerfile) if cli_conf.dockerfile else None,
-            self.CONFIG_IMAGE: cli_conf.image,
+            self.CONFIG_BEHAVE_DATA: cli_conf.behave_data,
+            self.CONFIG_BEHAVE_TAGS: cli_conf.behave_tags,
             self.CONFIG_JUNIT: cli_conf.junit,
             self.CONFIG_EXEC_TYPE: 'ansible',
             self.CONFIG_REMOTE_TYPE: cli_conf.remote_type,


### PR DESCRIPTION
This is my proposal patch to make ctf usable more even for testing openshift templates where there are no dockerfiles or image names, do you have any comments on way its implemented?

I removed --dockerfile and --image parameteres - if ctf has to be used in more common way they're not required all the time
you can now specify them via --behave-data DOCKERFILE=aaa and --behave-data IMAGE=bbb options in more generic way, also you can specify any option this way
