### PR TITLE
Fix `ImportError: No module named runner` if Ansible 2.x is used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible<2.0
 behave>=1.2.5
 markupsafe
 six>=1.9.0


### PR DESCRIPTION
The ansible version is not pinned in the requirements.txt file.
Ansible API v2 brought breaking changes... ctf-cli does not like it.

Following the instructions from the README:

```
(ctf) ⚡ root@vps261671  ~/workspace/example-project-postgresql   master ✚  pip list
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
ansible (2.2.0.0)
behave (1.2.5)
cffi (1.9.1)
cryptography (1.6)
ctf-cli (1.0.2)
enum34 (1.1.6)
idna (2.1)
ipaddress (1.0.17)
Jinja2 (2.8)
MarkupSafe (0.23)
paramiko (2.1.0)
parse (1.6.6)
parse-type (0.3.4)
pip (9.0.1)
pyasn1 (0.1.9)
pycparser (2.17)
pycrypto (2.6.1)
PyYAML (3.12)
setuptools (30.4.0)
six (1.10.0)
wheel (0.29.0)

(ctf) ⚡ root@vps261671  ~/workspace/example-project-postgresql   master ✚  git rev-parse HEAD
5fa2086e823d41897e2b2b290d26bc8fb189e294

(ctf) ⚡ root@vps261671  ~/workspace/example-project-postgresql   master ✚  ctf-cli run
INFO:   Running Containers Testing Framework cli
INFO:   Using project specific Features from 'tests/features'
INFO:   Using project specific Steps from 'tests/steps'
INFO:   Using project specific environment.py from 'tests/environment.py'
INFO:   Running behave inside working directory 'behave -D ANSIBLE=/root/workspace/example-project-postgresql/workdir/ansible.conf'
Exception ImportError: No module named runner
Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/ctf/bin/behave", line 11, in <module>
    sys.exit(main())
  File "/root/.local/share/virtualenvs/ctf/local/lib/python2.7/site-packages/behave/__main__.py", line 109, in main
    failed = runner.run()
  File "/root/.local/share/virtualenvs/ctf/local/lib/python2.7/site-packages/behave/runner.py", line 672, in run
    return self.run_with_paths()
  File "/root/.local/share/virtualenvs/ctf/local/lib/python2.7/site-packages/behave/runner.py", line 677, in run_with_paths
    self.load_hooks()
  File "/root/.local/share/virtualenvs/ctf/local/lib/python2.7/site-packages/behave/runner.py", line 631, in load_hooks
    exec_file(hooks_path, self.hooks)
  File "/root/.local/share/virtualenvs/ctf/local/lib/python2.7/site-packages/behave/runner.py", line 304, in exec_file
    exec(code, globals, locals)
  File "environment.py", line 1, in <module>
    from steps.common_steps.common_environment import docker_setup
  File "/root/workspace/example-project-postgresql/workdir/steps/common_steps/common_environment.py", line 4, in <module>
    import ansible.runner
ImportError: No module named runner

```